### PR TITLE
Recording counts for each handle separately.

### DIFF
--- a/lib/prop.rb
+++ b/lib/prop.rb
@@ -54,7 +54,7 @@ class Prop
 
     def throttle!(handle, key = nil, options = {})
       options   = sanitized_prop_options(handle, key, options)
-      cache_key = sanitized_prop_key(key, options[:interval])
+      cache_key = sanitized_prop_key(handle, key, options)
       counter   = reader.call(cache_key).to_i
 
       return counter if disabled?
@@ -68,21 +68,21 @@ class Prop
 
     def throttled?(handle, key = nil, options = {})
       options   = sanitized_prop_options(handle, key, options)
-      cache_key = sanitized_prop_key(key, options[:interval])
+      cache_key = sanitized_prop_key(handle, key, options)
 
       reader.call(cache_key).to_i >= options[:threshold]
     end
 
     def reset(handle, key = nil, options = {})
       options   = sanitized_prop_options(handle, key, options)
-      cache_key = sanitized_prop_key(key, options[:interval])
+      cache_key = sanitized_prop_key(handle, key, options)
 
       writer.call(cache_key, 0)
     end
 
     def query(handle, key = nil, options = {})
       options   = sanitized_prop_options(handle, key, options)
-      cache_key = sanitized_prop_key(key, options[:interval])
+      cache_key = sanitized_prop_key(handle, key, options)
 
       reader.call(cache_key).to_i
     end
@@ -91,9 +91,9 @@ class Prop
     private
 
     # Builds the expiring cache key
-    def sanitized_prop_key(key, interval)
-      window    = (Time.now.to_i / interval)
-      cache_key = "#{normalize_cache_key(key)}/#{ window }"
+    def sanitized_prop_key(handle, key, options)
+      window    = (Time.now.to_i / options[:interval])
+      cache_key = normalize_cache_key([handle, key, window])
       "prop/#{Digest::MD5.hexdigest(cache_key)}"
     end
 

--- a/test/test_prop.rb
+++ b/test/test_prop.rb
@@ -179,5 +179,19 @@ class TestProp < Test::Unit::TestCase
       end
     end
 
+    context 'different handles with the same interval' do
+      setup do
+        Prop.configure(:api_requests, :threshold => 100, :interval => 30)
+        Prop.configure(:login_attempts, :threshold => 10, :interval => 30)
+      end
+
+      should 'be counted separately' do
+        user_id = 42
+        Prop.throttle!(:api_requests, user_id)
+        assert_equal(1, Prop.count(:api_requests, user_id))
+        assert_equal(0, Prop.count(:login_attempts, user_id))
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Previously, we could define two different handles in such a way that they would both be counted together. For example, if we defined handle `:foo` and handle `:bar` both with the same interval, when we incremented one of the counters the other one would be incremented as well.

Now we keep the `:foo` counter and the `:bar` counter separate.

/cc @dadah89
