### PR TITLE
Add support for before_throttle callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ end
 
 You can choose to rely on whatever you'd like to use for transient storage. Prop does not do any sort of clean up of its key space, so you would have to implement that manually should you be using anything but an LRU cache like memcached.
 
+## Setting a Callback
+
+You can define an optional callback that is invoked when a rate limit is reached. In a Rails application you could use such a handler to add notification support:
+
+```ruby
+Prop.before_throttle do |handle, key, threshold, interval|
+  ActiveSupport::Notifications.instrument('throttle.prop', handle: handle, key: key, threshold: threshold, interval: interval)
+end
+```
+
 ## Defining thresholds
 
 Once the read and write operations are defined, you can optionally define thresholds. If, for example, you want to have a threshold on accepted emails per hour from a given user, you could define a threshold and interval (in seconds) for this like so:

--- a/lib/prop.rb
+++ b/lib/prop.rb
@@ -7,7 +7,7 @@ module Prop
   # Short hand for accessing Prop::Limiter methods
   class << self
     extend Forwardable
-    def_delegators :"Prop::Limiter", :read, :write, :configure, :disabled
+    def_delegators :"Prop::Limiter", :read, :write, :configure, :disabled, :before_throttle
     def_delegators :"Prop::Limiter", :throttle!, :throttled?, :count, :query, :reset
   end
 end

--- a/test/test_limiter.rb
+++ b/test/test_limiter.rb
@@ -64,6 +64,25 @@ class TestLimiter < Test::Unit::TestCase
               assert_raises(Prop::RateLimited) { Prop.throttle!(:something) }
             end
           end
+
+          context "and given a before_throttle callback" do
+            setup do
+              Prop.before_throttle do |handle, key, threshold, interval|
+                @handle = handle
+                @key = key
+                @threshold = threshold
+                @interval = interval
+              end
+            end
+
+            should "invoke callback with expected parameters" do
+              assert_raises(Prop::RateLimited) { Prop.throttle!(:something, [:extra]) }
+              assert_equal @handle, :something
+              assert_equal @key, [:extra]
+              assert_equal @threshold, 10
+              assert_equal @interval, 10
+            end
+          end
         end
 
         context "and threshold has not been reached" do


### PR DESCRIPTION
This PR adds support for a before-throttle callback in order to allow integration with notification and logging frameworks, e.g. ActiveSupport::Notifications, without relying on exceptions.

@morten 
