### PR TITLE
fix that race condition

### DIFF
--- a/lib/prop/interval_strategy.rb
+++ b/lib/prop/interval_strategy.rb
@@ -9,17 +9,18 @@ module Prop
         Prop::Limiter.cache.read(cache_key).to_i
       end
 
-      def increment(cache_key, options, counter)
+      def increment(cache_key, options)
         increment = options.fetch(:increment, 1)
-        Prop::Limiter.cache.write(cache_key, counter + increment)
+        cache = Prop::Limiter.cache
+        cache.increment(cache_key, increment) || cache.write(cache_key, increment) # WARNING: potential race condition
       end
 
       def reset(cache_key)
         Prop::Limiter.cache.write(cache_key, 0)
       end
 
-      def at_threshold?(counter, options)
-        counter >= options.fetch(:threshold)
+      def compare_threshold?(counter, operator, options)
+        counter.send operator, options.fetch(:threshold)
       end
 
       # Builds the expiring cache key

--- a/test/test_interval_strategy.rb
+++ b/test/test_interval_strategy.rb
@@ -24,9 +24,15 @@ describe Prop::IntervalStrategy do
   end
 
   describe "#increment" do
-    it "increments the bucket" do
-      Prop::IntervalStrategy.increment(@key, { increment: 5 }, 1)
-      Prop::IntervalStrategy.counter(@key, nil).must_equal 6
+    it "increments an empty bucket" do
+      Prop::IntervalStrategy.increment(@key, increment: 5)
+      assert_equal 5, Prop::IntervalStrategy.counter(@key, nil)
+    end
+
+    it "increments a filled bucket" do
+      Prop::IntervalStrategy.increment(@key, increment: 5)
+      Prop::IntervalStrategy.increment(@key, increment: 5)
+      assert_equal 10, Prop::IntervalStrategy.counter(@key, nil)
     end
   end
 
@@ -39,13 +45,15 @@ describe Prop::IntervalStrategy do
     end
   end
 
-  describe "#at_threshold?" do
+  describe "#compare_threshold?" do
     it "returns true when the limit has been reached" do
-      assert Prop::IntervalStrategy.at_threshold?(100, { threshold: 100 })
+      assert Prop::IntervalStrategy.compare_threshold?(100, :>=, { threshold: 100 })
+      assert Prop::IntervalStrategy.compare_threshold?(101, :>, { threshold: 100 })
     end
 
     it "returns false when the limit has not been reached" do
-      refute Prop::IntervalStrategy.at_threshold?(99, { threshold: 100 })
+      refute Prop::IntervalStrategy.compare_threshold?(99, :>=, { threshold: 100 })
+      refute Prop::IntervalStrategy.compare_threshold?(100, :>, { threshold: 100 })
     end
   end
 


### PR DESCRIPTION
@staugaard @morten @pschambacher @shanitang 

atm prop is build on a race condition ... we read, compare, write :(

leaky bucket strategy will just stay racy because we cannot use atomic increments there ...

sounds like a good change / am I missing something ?

### Risks
 - None