### PR TITLE
do not show consusing double quoted key

### DIFF
--- a/lib/prop/interval_strategy.rb
+++ b/lib/prop/interval_strategy.rb
@@ -38,7 +38,7 @@ module Prop
       def threshold_reached(options)
         threshold = options.fetch(:threshold)
 
-        "#{options[:handle]} threshold of #{threshold} tries per #{options[:interval]}s exceeded for key '#{options[:key].inspect}', hash #{options[:cache_key]}"
+        "#{options[:handle]} threshold of #{threshold} tries per #{options[:interval]}s exceeded for key #{options[:key].inspect}, hash #{options[:cache_key]}"
       end
 
       def validate_options!(options)

--- a/lib/prop/leaky_bucket_strategy.rb
+++ b/lib/prop/leaky_bucket_strategy.rb
@@ -46,7 +46,7 @@ module Prop
         burst_rate = options.fetch(:burst_rate)
         threshold  = options.fetch(:threshold)
 
-        "#{options[:handle]} threshold of #{threshold} tries per #{options[:interval]}s and burst rate #{burst_rate} tries exceeded for key '#{options[:key].inspect}', hash #{options[:cache_key]}"
+        "#{options[:handle]} threshold of #{threshold} tries per #{options[:interval]}s and burst rate #{burst_rate} tries exceeded for key #{options[:key].inspect}, hash #{options[:cache_key]}"
       end
 
       def validate_options!(options)

--- a/test/test_rate_limited.rb
+++ b/test/test_rate_limited.rb
@@ -24,7 +24,7 @@ describe Prop::RateLimited do
       @error.handle.must_equal :foo
       @error.cache_key.must_equal "wibble"
       @error.description.must_equal "Boom!"
-      @error.message.must_equal "foo threshold of 10 tries per 60s exceeded for key 'nil', hash wibble"
+      @error.message.must_equal "foo threshold of 10 tries per 60s exceeded for key nil, hash wibble"
       @error.retry_after.must_equal 20
     end
   end


### PR DESCRIPTION
@ggrossman 

before: ` tries per 600s exceeded for key '"throttled_rule_ticket_finder-37006-57888-c1b9ec764e63f88b054fd4e5c1f53fef"', hash `
after: ` tries per 600s exceeded for key "throttled_rule_ticket_finder-37006-57888-c1b9ec764e63f88b054fd4e5c1f53fef", hash `

we normalize all keys into strings, so just inspect is good enough
