### PR TITLE
use different key since old read and increment do not work together

### DIFF
--- a/lib/prop/interval_strategy.rb
+++ b/lib/prop/interval_strategy.rb
@@ -32,7 +32,7 @@ module Prop
         window    = (Time.now.to_i / interval)
         cache_key = Prop::Key.normalize([ handle, key, window ])
 
-        "prop/#{Digest::MD5.hexdigest(cache_key)}"
+        "prop/v2/#{Digest::MD5.hexdigest(cache_key)}"
       end
 
       def threshold_reached(options)

--- a/test/test_interval_strategy.rb
+++ b/test/test_interval_strategy.rb
@@ -59,7 +59,7 @@ describe Prop::IntervalStrategy do
 
   describe "#build" do
     it "returns a hexdigested key" do
-      Prop::IntervalStrategy.build(handle: :hello, key: [ "foo", 2, :bar ], interval: 60).must_match /prop\/[a-f0-9]+/
+      Prop::IntervalStrategy.build(handle: :hello, key: [ "foo", 2, :bar ], interval: 60).must_match /prop\/v2\/[a-f0-9]+/
     end
   end
 


### PR DESCRIPTION
increment needs a raw value, but old values are not raw ... so use a new namespace to avoid any funkyness

@pschambacher @ggrossman 

### Risks
 - None