### PR TITLE
handle memcached is unavailable when using Dalli

### DIFF
--- a/lib/prop/interval_strategy.rb
+++ b/lib/prop/interval_strategy.rb
@@ -21,6 +21,7 @@ module Prop
       end
 
       def compare_threshold?(counter, operator, options)
+        return false unless counter.respond_to? operator
         counter.send operator, options.fetch(:threshold)
       end
 

--- a/lib/prop/interval_strategy.rb
+++ b/lib/prop/interval_strategy.rb
@@ -21,7 +21,7 @@ module Prop
       end
 
       def compare_threshold?(counter, operator, options)
-        return false unless counter.respond_to? operator
+        return false unless counter
         counter.send operator, options.fetch(:threshold)
       end
 

--- a/test/test_interval_strategy.rb
+++ b/test/test_interval_strategy.rb
@@ -61,6 +61,11 @@ describe Prop::IntervalStrategy do
       refute Prop::IntervalStrategy.compare_threshold?(99, :>=, { threshold: 100 })
       refute Prop::IntervalStrategy.compare_threshold?(100, :>, { threshold: 100 })
     end
+
+    it "returns false when the counter fails to increment" do
+      refute Prop::IntervalStrategy.compare_threshold?(false, :>, { threshold: 100 })
+      refute Prop::IntervalStrategy.compare_threshold?(nil, :>, { threshold: 100 })
+    end
   end
 
   describe "#build" do


### PR DESCRIPTION
:koala:

`@strategy.increment` returns `false`, we then try to call comparison functions on it.

/cc @zendesk/quokka @shanitang @grosser 