### PR TITLE
support decrement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ rvm:
   - 2.2.2
   - 2.1.6
   - 2.0.0
-  - 1.9.3
   - jruby
 branches:
   only: [master]

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
 source 'https://rubygems.org'
 
+# TODO: 5.0.0 breaks on 2.0 and 2.1 which we still want to support ... add multiple gemfiles
 gem 'activesupport', '~> 4.2.6'
+
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
+gem 'activesupport', '~> 4.2.6'
 gemspec

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Prop.configure(:execute_time, threshold: 10, interval: 1.minute)
 Prop.throttle!(:execute_time, account.id, increment: (Benchmark.realtime { execute }).to_i)
 ```
 
-We also support decrement, in case of api failures we do not increase rate limits.
+Decrement can be used to for example throttle before an expensive action and then give quota back when some condition is met.
 `:decrement` is only supported for `IntervalStrategy` for now
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -157,6 +157,13 @@ Prop.configure(:execute_time, threshold: 10, interval: 1.minute)
 Prop.throttle!(:execute_time, account.id, increment: (Benchmark.realtime { execute }).to_i)
 ```
 
+We also support decrement, in case of api failures we do not increase rate limits.
+`:decrement` is only supported for `IntervalStrategy` for now
+
+```ruby
+Prop.throttle!(:api_counts, request.remote_ip, decrement: 1)
+```
+
 ## Optional configuration
 
 You can add optional configuration to a prop and retrieve it using `Prop.configurations[:foo]`:

--- a/lib/prop/interval_strategy.rb
+++ b/lib/prop/interval_strategy.rb
@@ -13,18 +13,10 @@ module Prop
         Prop::Limiter.cache.read(cache_key).to_i
       end
 
-      def increment(cache_key, options)
-        change(cache_key, options.fetch(:increment, 1))
-      end
-
-      def decrement(cache_key, options)
-        if counter(cache_key, options) <= zero_counter
-          raise ArgumentError, "Can not decrease below #{zero_counter}"
-        end
-        change(cache_key, -(options.fetch(:decrement, 1)))
-      end
-
-      def change(cache_key, amount)
+      def change(cache_key, options)
+        amount = options.key?(:decrement) ?
+          -(options.fetch(:decrement)) :
+          options.fetch(:increment, 1)
         raise ArgumentError, "Change amount must be a Fixnum, was #{amount.class}" unless amount.is_a?(Fixnum)
         cache = Prop::Limiter.cache
         cache.increment(cache_key, amount) || (cache.write(cache_key, amount, raw: true) && amount) # WARNING: potential race condition

--- a/lib/prop/leaky_bucket_strategy.rb
+++ b/lib/prop/leaky_bucket_strategy.rb
@@ -18,7 +18,9 @@ module Prop
       # WARNING: race condition
       # this increment is not atomic, so it might miss counts when used frequently
       def change(cache_key, options)
+        # please open a PR if you know how to support this
         raise ArgumentError, "decrement is not supported for LeakyBucketStrategy" if options.key?(:decrement)
+
         counter = counter(cache_key, options)
         counter[:bucket] += options.fetch(:increment, 1)
         Prop::Limiter.cache.write(cache_key, counter)

--- a/lib/prop/leaky_bucket_strategy.rb
+++ b/lib/prop/leaky_bucket_strategy.rb
@@ -17,15 +17,12 @@ module Prop
 
       # WARNING: race condition
       # this increment is not atomic, so it might miss counts when used frequently
-      def increment(cache_key, options)
+      def change(cache_key, options)
+        raise ArgumentError, "decrement is not supported for LeakyBucketStrategy" if options.key?(:decrement)
         counter = counter(cache_key, options)
         counter[:bucket] += options.fetch(:increment, 1)
         Prop::Limiter.cache.write(cache_key, counter)
         counter
-      end
-
-      def decrement(cache_key, options)
-        raise ArgumentError.new("decrement is not supported for this strategy")
       end
 
       def reset(cache_key)

--- a/lib/prop/leaky_bucket_strategy.rb
+++ b/lib/prop/leaky_bucket_strategy.rb
@@ -24,6 +24,10 @@ module Prop
         counter
       end
 
+      def decrement(cache_key, options)
+        raise ArgumentError.new("decrement is not supported for this strategy")
+      end
+
       def reset(cache_key)
         Prop::Limiter.cache.write(cache_key, zero_counter)
       end

--- a/lib/prop/limiter.rb
+++ b/lib/prop/limiter.rb
@@ -146,7 +146,9 @@ module Prop
       def _throttle(handle, key, cache_key, options)
         return [false, @strategy.zero_counter] if disabled?
 
-        counter = @strategy.increment(cache_key, options)
+        counter = options.key?(:decrement) ?
+          @strategy.decrement(cache_key, options) :
+          @strategy.increment(cache_key, options)
 
         if @strategy.compare_threshold?(counter, :>, options)
           before_throttle_callback &&

--- a/lib/prop/limiter.rb
+++ b/lib/prop/limiter.rb
@@ -146,9 +146,7 @@ module Prop
       def _throttle(handle, key, cache_key, options)
         return [false, @strategy.zero_counter] if disabled?
 
-        counter = options.key?(:decrement) ?
-          @strategy.decrement(cache_key, options) :
-          @strategy.increment(cache_key, options)
+        counter = @strategy.change(cache_key, options)
 
         if @strategy.compare_threshold?(counter, :>, options)
           before_throttle_callback &&

--- a/prop.gemspec
+++ b/prop.gemspec
@@ -16,5 +16,6 @@ Gem::Specification.new "prop", Prop::VERSION do |s|
   s.add_development_dependency('activesupport')
   s.add_development_dependency('bump')
 
+  s.required_ruby_version = '>= 2.0'
   s.files = `git ls-files lib LICENSE README.md`.split("\n")
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -8,7 +8,6 @@ require 'time'
 require 'prop'
 require 'active_support/cache'
 require 'active_support/cache/memory_store'
-require 'active_support/notifications'
 
 Minitest::Test.class_eval do
   def setup_fake_store

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -8,6 +8,7 @@ require 'time'
 require 'prop'
 require 'active_support/cache'
 require 'active_support/cache/memory_store'
+require 'active_support/notifications'
 
 Minitest::Test.class_eval do
   def setup_fake_store

--- a/test/test_interval_strategy.rb
+++ b/test/test_interval_strategy.rb
@@ -43,6 +43,20 @@ describe Prop::IntervalStrategy do
     end
   end
 
+  describe "#decrement" do
+    it "raises error when decrements an empty bucket" do
+      assert_raises ArgumentError do
+        Prop::IntervalStrategy.decrement(@key, decrement: 1)
+      end
+    end
+
+    it "does not write non-integers" do
+      assert_raises ArgumentError do
+        Prop::IntervalStrategy.decrement(@key, decrement: "WHOOPS")
+      end
+    end
+  end
+
   describe "#reset" do
     before { Prop::Limiter.cache.write(@key, 100) }
 

--- a/test/test_interval_strategy.rb
+++ b/test/test_interval_strategy.rb
@@ -24,35 +24,26 @@ describe Prop::IntervalStrategy do
     end
   end
 
-  describe "#increment" do
+  describe "#change" do
     it "increments an empty bucket" do
-      Prop::IntervalStrategy.increment(@key, increment: 5)
+      Prop::IntervalStrategy.change(@key, increment: 5)
       assert_equal 5, Prop::IntervalStrategy.counter(@key, nil)
     end
 
+    it "decrements an empty bucket" do
+      Prop::IntervalStrategy.change(@key, decrement: 5)
+      assert_equal -5, Prop::IntervalStrategy.counter(@key, nil)
+    end
+
     it "increments a filled bucket" do
-      Prop::IntervalStrategy.increment(@key, increment: 5)
-      Prop::IntervalStrategy.increment(@key, increment: 5)
+      Prop::IntervalStrategy.change(@key, increment: 5)
+      Prop::IntervalStrategy.change(@key, increment: 5)
       assert_equal 10, Prop::IntervalStrategy.counter(@key, nil)
     end
 
     it "does not write non-integers" do
       assert_raises ArgumentError do
-        Prop::IntervalStrategy.increment(@key, increment: "WHOOPS")
-      end
-    end
-  end
-
-  describe "#decrement" do
-    it "raises error when decrements an empty bucket" do
-      assert_raises ArgumentError do
-        Prop::IntervalStrategy.decrement(@key, decrement: 1)
-      end
-    end
-
-    it "does not write non-integers" do
-      assert_raises ArgumentError do
-        Prop::IntervalStrategy.decrement(@key, decrement: "WHOOPS")
+        Prop::IntervalStrategy.change(@key, increment: "WHOOPS")
       end
     end
   end

--- a/test/test_leaky_bucket_strategy.rb
+++ b/test/test_leaky_bucket_strategy.rb
@@ -28,16 +28,22 @@ describe Prop::LeakyBucketStrategy do
     end
   end
 
-  describe "#increment" do
+  describe "#change" do
     it "increments an empty bucket" do
-      Prop::LeakyBucketStrategy.increment(@key, increment: 5, interval: 1, threshold: 10)
+      Prop::LeakyBucketStrategy.change(@key, increment: 5, interval: 1, threshold: 10)
       Prop::Limiter.cache.read(@key).must_equal bucket: 5, last_updated: @time.to_i
     end
 
     it "increments an existing bucket" do
-      Prop::LeakyBucketStrategy.increment(@key, increment: 5, interval: 1, threshold: 10)
-      Prop::LeakyBucketStrategy.increment(@key, increment: 5, interval: 1, threshold: 10)
+      Prop::LeakyBucketStrategy.change(@key, increment: 5, interval: 1, threshold: 10)
+      Prop::LeakyBucketStrategy.change(@key, increment: 5, interval: 1, threshold: 10)
       Prop::Limiter.cache.read(@key).must_equal bucket: 10, last_updated: @time.to_i
+    end
+
+    it "decrements an empty bucket" do
+      assert_raises ArgumentError do
+        Prop::LeakyBucketStrategy.change(@key, decrement: 5)
+      end
     end
   end
 

--- a/test/test_leaky_bucket_strategy.rb
+++ b/test/test_leaky_bucket_strategy.rb
@@ -40,7 +40,7 @@ describe Prop::LeakyBucketStrategy do
       Prop::Limiter.cache.read(@key).must_equal bucket: 10, last_updated: @time.to_i
     end
 
-    it "decrements an empty bucket" do
+    it "cannot decrement an empty bucket" do
       assert_raises ArgumentError do
         Prop::LeakyBucketStrategy.change(@key, decrement: 5)
       end

--- a/test/test_limiter.rb
+++ b/test/test_limiter.rb
@@ -24,7 +24,7 @@ describe Prop::Limiter do
         Prop.throttle(:something)
         Prop.count(:something).must_equal 1
 
-        Prop.throttle(:something, decrement: 1)
+        Prop.throttle(:something, nil, decrement: 1)
         Prop.count(:something).must_equal 0
       end
 

--- a/test/test_limiter.rb
+++ b/test/test_limiter.rb
@@ -20,12 +20,12 @@ describe Prop::Limiter do
         Prop::Limiter.disabled { Prop.throttle(:something) }.must_equal false
       end
 
-      it "supports decrement" do
+      it "supports decrement and can below 0" do
         Prop.throttle(:something)
         Prop.count(:something).must_equal 1
 
-        Prop.throttle(:something, nil, decrement: 1)
-        Prop.count(:something).must_equal 0
+        Prop.throttle(:something, nil, decrement: 5)
+        Prop.count(:something).must_equal -4
       end
 
       describe "and the threshold has been reached" do

--- a/test/test_limiter.rb
+++ b/test/test_limiter.rb
@@ -20,6 +20,14 @@ describe Prop::Limiter do
         Prop::Limiter.disabled { Prop.throttle(:something) }.must_equal false
       end
 
+      it "supports decrement" do
+        Prop.throttle(:something)
+        Prop.count(:something).must_equal 1
+
+        Prop.throttle(:something, decrement: 1)
+        Prop.count(:something).must_equal 0
+      end
+
       describe "and the threshold has been reached" do
         before { Prop::IntervalStrategy.stubs(:compare_threshold?).returns(true) }
 


### PR DESCRIPTION
Support decrement method for `IntervalStrategy`

In case of api failures we want to decrement the rate limit
```
Prop.throttle!(:api_counts, request.remote_ip, decrement: 1)
```