### PR TITLE
use decrement to avoid float underflow

### DIFF
--- a/lib/prop/leaky_bucket_strategy.rb
+++ b/lib/prop/leaky_bucket_strategy.rb
@@ -17,9 +17,17 @@ module Prop
 
       # WARNING: race condition
       # this increment is not atomic, so it might miss counts when used frequently
-      def change(cache_key, amount, options)
+      def increment(cache_key, amount, options)
         counter = counter(cache_key, options)
         counter[:bucket] += amount
+        Prop::Limiter.cache.write(cache_key, counter)
+        counter
+      end
+
+      def decrement(cache_key, amount, options)
+        counter = counter(cache_key, options)
+        counter[:bucket] -= amount
+        counter[:bucket] = 0 unless counter[:bucket] > 0
         Prop::Limiter.cache.write(cache_key, counter)
         counter
       end

--- a/lib/prop/limiter.rb
+++ b/lib/prop/limiter.rb
@@ -20,7 +20,7 @@ module Prop
       end
 
       def cache=(cache)
-        [:read, :write, :increment].each do |method|
+        [:read, :write, :increment, :decrement].each do |method|
           next if cache.respond_to?(method)
           raise ArgumentError, "Cache needs to respond to #{method}"
         end
@@ -146,10 +146,9 @@ module Prop
       def _throttle(handle, key, cache_key, options)
         return [false, @strategy.zero_counter] if disabled?
 
-        amount = options.key?(:decrement) ?
-          -(options.fetch(:decrement)) :
-          options.fetch(:increment, 1)
-        counter = @strategy.change(cache_key, amount, options)
+        counter = options.key?(:decrement) ?
+          @strategy.decrement(cache_key, options.fetch(:decrement), options) :
+          @strategy.increment(cache_key, options.fetch(:increment, 1), options)
 
         if @strategy.compare_threshold?(counter, :>, options)
           before_throttle_callback &&

--- a/test/test_interval_strategy.rb
+++ b/test/test_interval_strategy.rb
@@ -24,26 +24,40 @@ describe Prop::IntervalStrategy do
     end
   end
 
-  describe "#change" do
+  describe "#increment" do
     it "increments an empty bucket" do
-      Prop::IntervalStrategy.change(@key, 5)
+      Prop::IntervalStrategy.increment(@key, 5)
       assert_equal 5, Prop::IntervalStrategy.counter(@key, nil)
     end
 
-    it "decrements an empty bucket" do
-      Prop::IntervalStrategy.change(@key, -5)
-      assert_equal -5, Prop::IntervalStrategy.counter(@key, nil)
-    end
-
     it "increments a filled bucket" do
-      Prop::IntervalStrategy.change(@key, 5)
-      Prop::IntervalStrategy.change(@key, 5)
+      Prop::IntervalStrategy.increment(@key, 5)
+      Prop::IntervalStrategy.increment(@key, 5)
       assert_equal 10, Prop::IntervalStrategy.counter(@key, nil)
     end
 
     it "does not write non-integers" do
       assert_raises ArgumentError do
-        Prop::IntervalStrategy.change(@key, "WHOOPS")
+        Prop::IntervalStrategy.increment(@key, "WHOOPS")
+      end
+    end
+  end
+
+  describe "#decrement" do
+    it "returns 0 when decrements an empty bucket" do
+      Prop::IntervalStrategy.decrement(@key, -5)
+      assert_equal 0, Prop::IntervalStrategy.counter(@key, nil)
+    end
+
+    it "decrements a filled bucket" do
+      Prop::IntervalStrategy.increment(@key, 5)
+      Prop::IntervalStrategy.decrement(@key, 2)
+      assert_equal 3, Prop::IntervalStrategy.counter(@key, nil)
+    end
+
+    it "does not write non-integers" do
+      assert_raises ArgumentError do
+        Prop::IntervalStrategy.decrement(@key, "WHOOPS")
       end
     end
   end

--- a/test/test_leaky_bucket_strategy.rb
+++ b/test/test_leaky_bucket_strategy.rb
@@ -28,21 +28,29 @@ describe Prop::LeakyBucketStrategy do
     end
   end
 
-  describe "#change" do
+  describe "#increment" do
     it "increments an empty bucket" do
-      Prop::LeakyBucketStrategy.change(@key, 5, interval: 1, threshold: 10)
+      Prop::LeakyBucketStrategy.increment(@key, 5, interval: 1, threshold: 10)
       Prop::Limiter.cache.read(@key).must_equal bucket: 5, last_updated: @time.to_i
     end
 
     it "increments an existing bucket" do
-      Prop::LeakyBucketStrategy.change(@key, 5, interval: 1, threshold: 10)
-      Prop::LeakyBucketStrategy.change(@key, 5, interval: 1, threshold: 10)
+      Prop::LeakyBucketStrategy.increment(@key, 5, interval: 1, threshold: 10)
+      Prop::LeakyBucketStrategy.increment(@key, 5, interval: 1, threshold: 10)
       Prop::Limiter.cache.read(@key).must_equal bucket: 10, last_updated: @time.to_i
     end
+  end
 
-    it "can decrement an empty bucket" do
-      Prop::LeakyBucketStrategy.change(@key, -5, interval: 1, threshold: 10)
-      Prop::Limiter.cache.read(@key).must_equal bucket: -5, last_updated: @time.to_i
+  describe "#decrement" do
+    it "returns 0 when decrement an empty bucket" do
+      Prop::LeakyBucketStrategy.decrement(@key, 5, interval: 1, threshold: 10)
+      Prop::Limiter.cache.read(@key).must_equal bucket: 0, last_updated: @time.to_i
+    end
+
+    it "decrements an existing bucket" do
+      Prop::LeakyBucketStrategy.increment(@key, 5, interval: 1, threshold: 10)
+      Prop::LeakyBucketStrategy.decrement(@key, 3, interval: 1, threshold: 10)
+      Prop::Limiter.cache.read(@key).must_equal bucket: 2, last_updated: @time.to_i
     end
   end
 


### PR DESCRIPTION
### Description
Issue `1 - 1 = 4294967296`? We should use decrement not increment by `-1`.

```
zendesk(dev)> Prop.throttle(:account_creations, 'key')
=> false
zendesk(dev)> Prop.count(:account_creations, 'key')
=> 1
zendesk(dev)> Prop.throttle(:account_creations, 'key', {decrement: 1})
=> true
zendesk(dev)> Prop.count(:account_creations, 'key')
=> 4294967296
```

### Changes made
* We can not decrement below 0 for both strategies, because memcache can only decrement to `0` not negative numbers.

  ```
zendesk(dev)> Rails.cache.write(:test, 0, raw:true)
=> true
zendesk(dev)> Rails.cache.read(:test)
=> "0"
zendesk(dev)> Rails.cache.decrement(:test, 10)
=> 0
zendesk(dev)> Rails.cache.read(:test)
=> "0"
```

* cache must support `decrement` method

@grosser 