### PR TITLE
add a reader for cache to top level prop module

### DIFF
--- a/lib/prop.rb
+++ b/lib/prop.rb
@@ -8,7 +8,7 @@ module Prop
   # Short hand for accessing Prop::Limiter methods
   class << self
     extend Forwardable
-    def_delegators :"Prop::Limiter", :read, :write, :cache=, :configure, :configurations, :disabled, :before_throttle
+    def_delegators :"Prop::Limiter", :read, :write, :cache, :cache=, :configure, :configurations, :disabled, :before_throttle
     def_delegators :"Prop::Limiter", :throttle, :throttle!, :throttled?, :count, :query, :reset
   end
 end


### PR DESCRIPTION
It would be nice to be able to say `Prop.cache.clear` or `Prop.cache.stats` instead of having to say `Prop::Limiter.cache.foo`

/cc @pschambacher @grosser @dadah89 @jcheatham 