### PR TITLE
Fix leaky bucket leak calculation

### DIFF
--- a/lib/prop/leaky_bucket_strategy.rb
+++ b/lib/prop/leaky_bucket_strategy.rb
@@ -8,9 +8,10 @@ module Prop
       def counter(cache_key, options)
         bucket = Prop::Limiter.cache.read(cache_key) || zero_counter
         now = Time.now.to_i
-        leak_amount = (now - bucket.fetch(:last_updated)) / options.fetch(:interval) * options.fetch(:threshold)
+        leak_rate = (now - bucket.fetch(:last_updated)) / options.fetch(:interval).to_f
+        leak_amount =  leak_rate * options.fetch(:threshold)
 
-        bucket[:bucket] = [bucket.fetch(:bucket) - leak_amount, 0].max
+        bucket[:bucket] = [(bucket.fetch(:bucket) - leak_amount).to_i, 0].max
         bucket[:last_updated] = now
         bucket
       end

--- a/test/test_leaky_bucket_strategy.rb
+++ b/test/test_leaky_bucket_strategy.rb
@@ -68,6 +68,13 @@ describe Prop::LeakyBucketStrategy do
       Prop::LeakyBucketStrategy.decrement(@key, 3, interval: 1, threshold: 10)
       Prop::Limiter.cache.read(@key).must_equal bucket: 2, last_updated: @time.to_i
     end
+
+    it "adjusts bucket when elapsed time is less than interval" do
+      # bucket updated 5 seconds ago with leak rate of 1/second
+      Prop::Limiter.cache.write(@key, { bucket: 10, last_updated: @time.to_i - 5 })
+      Prop::LeakyBucketStrategy.decrement(@key, 0, interval: 60, threshold: 60)
+      Prop::Limiter.cache.read(@key).must_equal bucket: 5, last_updated: @time.to_i
+    end
   end
 
   describe "#reset" do

--- a/test/test_leaky_bucket_strategy.rb
+++ b/test/test_leaky_bucket_strategy.rb
@@ -26,6 +26,19 @@ describe Prop::LeakyBucketStrategy do
         Prop::LeakyBucketStrategy.counter(@key, interval: 1, threshold: 10).must_equal bucket_expected
       end
     end
+
+    describe 'when last_updated matches Time.now' do
+      before do
+        # bucket updated 5 seconds ago with leak rate of 1/second
+        @bucket = { bucket: 10, last_updated: @time.to_i }
+        Prop::Limiter.cache.write(@key, @bucket)
+      end
+
+      it 'does not affect the current bucket count' do
+        Prop::LeakyBucketStrategy.increment(@key, 0, interval: 60, threshold: 60)
+        Prop::Limiter.cache.read(@key).must_equal @bucket
+      end
+    end
   end
 
   describe "#increment" do


### PR DESCRIPTION
Fixes issue where the bucket does not leak when the time since last
update is less than the interval. This meant the bucket never leaked
and was only emptied if the limit wasn't checked for the entire interval

@zendesk/echidna @grosser 