### PR TITLE
Allow zero case for threshold when configure the prop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ tmtags
 coverage
 rdoc
 pkg
+vendor
 
 ## PROJECT::SPECIFIC
 Gemfile.lock

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Example: Limit on accepted emails per hour from a given user, by defining a thre
 
 ```ruby
 Prop.configure(:mails_per_hour, threshold: 100, interval: 1.hour, description: "Mail rate limit exceeded")
+
+# Block requests by setting threshold to 0
+Prop.configure(:mails_per_hour, threshold: 0, interval: 1.hour, description: "All mail is blocked")
 ```
 
 ```ruby

--- a/lib/prop/interval_strategy.rb
+++ b/lib/prop/interval_strategy.rb
@@ -56,8 +56,8 @@ module Prop
       end
 
       def validate_options!(options)
-        validate_positive_integer(options[:threshold], :threshold)
-        validate_positive_integer(options[:interval], :interval)
+        validate_threshold(options[:threshold], :threshold)
+        validate_interval(options[:interval], :interval)
 
         amount = options[:increment] || options[:decrement]
         if amount
@@ -67,7 +67,11 @@ module Prop
 
       private
 
-      def validate_positive_integer(option, key)
+      def validate_threshold(option, key)
+        raise ArgumentError.new("#{key.inspect} must be a non-negative Integer") if !option.is_a?(Integer) || option < 0
+      end
+
+      def validate_interval(option, key)
         raise ArgumentError.new("#{key.inspect} must be a positive Integer") if !option.is_a?(Integer) || option <= 0
       end
 

--- a/lib/prop/limiter.rb
+++ b/lib/prop/limiter.rb
@@ -46,8 +46,7 @@ module Prop
       #
       # Raises Prop::RateLimited if the number if the threshold for this handle has been reached
       def configure(handle, defaults)
-        raise ArgumentError.new("Invalid threshold setting") unless defaults[:threshold].to_i > 0
-        raise ArgumentError.new("Invalid interval setting")  unless defaults[:interval].to_i > 0
+        Prop::Options.validate_options!(defaults)
 
         self.handles ||= {}
         self.handles[handle] = defaults
@@ -56,7 +55,7 @@ module Prop
       # Public: Disables Prop for a block of code
       #
       # block    - a block of code within which Prop will not raise
-      def disabled(&block)
+      def disabled(&_block)
         @disabled = true
         yield
       ensure

--- a/lib/prop/options.rb
+++ b/lib/prop/options.rb
@@ -12,17 +12,24 @@ module Prop
       result   = defaults.merge(params)
 
       result[:key] = Prop::Key.normalize(key)
-
-      result[:strategy] = if leaky_bucket.include?(result[:strategy])
-        Prop::LeakyBucketStrategy
-      elsif result[:strategy] == nil
-        Prop::IntervalStrategy
-      else
-        result[:strategy] # allowing any new/unknown strategy to be used
-      end
+      result[:strategy] = get_strategy(result)
 
       result[:strategy].validate_options!(result)
       result
+    end
+
+    def self.validate_options!(options)
+      get_strategy(options).validate_options!(options)
+    end
+
+    def self.get_strategy(options)
+      if leaky_bucket.include?(options[:strategy])
+        Prop::LeakyBucketStrategy
+      elsif options[:strategy] == nil
+        Prop::IntervalStrategy
+      else
+        options[:strategy] # allowing any new/unknown strategy to be used
+      end
     end
 
     def self.leaky_bucket

--- a/test/test_interval_strategy.rb
+++ b/test/test_interval_strategy.rb
@@ -101,5 +101,12 @@ describe Prop::IntervalStrategy do
         refute Prop::IntervalStrategy.validate_options!(arg)
       end
     end
+
+    describe "when :threshold is set to zero to disable the prop" do
+      it "does not raise exception" do
+        arg = { threshold: 0, interval: 1, increment: 1}
+        refute Prop::IntervalStrategy.validate_options!(arg)
+      end
+    end
   end
 end

--- a/test/test_prop.rb
+++ b/test/test_prop.rb
@@ -50,6 +50,13 @@ describe Prop do
       Prop.throttle!(:hello_there, [ 5, '6' ]).must_equal 1
       Prop.throttle!(:hello_there, [ 5, '6' ]).must_equal 2
     end
+
+    it "allow to create 0 limit threshold" do
+      Prop.configure :hello_there, threshold: 0, interval: 10
+      assert_raises(Prop::RateLimited) do
+        Prop.throttle! :hello_there, 0
+      end
+    end
   end
 
   describe "#disable" do
@@ -61,6 +68,13 @@ describe Prop do
           count(Prop.throttle!(:hello)).must_equal 0
         end
         count(Prop.throttle!(:hello)).must_equal 2
+      end
+
+      it "does not increase the throttle with threshold 0" do
+        Prop.configure :hello, options.merge(threshold: 0, interval: 10)
+        Prop.disabled do
+          count(Prop.throttle!(:hello)).must_equal 0
+        end
       end
     end
   end


### PR DESCRIPTION
There an edge case when the request need to be rate limited as zero, Prop can not handle such case, throwing exception instead.
However, in this case the zero threshold should be still valid because eventually, it will handled by throttling.

@vanchi-zendesk @seancaffery @grosser @zendesk/argonauts 
