### PR TITLE
Make Prop.disabled thread-safe

### DIFF
--- a/lib/prop/limiter.rb
+++ b/lib/prop/limiter.rb
@@ -56,10 +56,10 @@ module Prop
       #
       # block    - a block of code within which Prop will not raise
       def disabled(&_block)
-        @disabled = true
+        Thread.current[:disabled] = true
         yield
       ensure
-        @disabled = false
+        Thread.current[:disabled] = false
       end
 
       # Public: Records a single action for the given handle/key combination.
@@ -174,7 +174,7 @@ module Prop
       end
 
       def disabled?
-        defined?(@disabled) && !!@disabled
+        Thread.current.key?(:disabled) && Thread.current[:disabled]
       end
 
       def prepare(handle, key, params)

--- a/lib/prop/limiter.rb
+++ b/lib/prop/limiter.rb
@@ -56,10 +56,10 @@ module Prop
       #
       # block    - a block of code within which Prop will not raise
       def disabled(&_block)
-        Thread.current[:disabled] = true
+        Thread.current[:prop_disabled] = true
         yield
       ensure
-        Thread.current[:disabled] = false
+        Thread.current[:prop_disabled] = false
       end
 
       # Public: Records a single action for the given handle/key combination.
@@ -174,7 +174,7 @@ module Prop
       end
 
       def disabled?
-        Thread.current.key?(:disabled) && Thread.current[:disabled]
+        Thread.current.key?(:prop_disabled) && Thread.current[:prop_disabled]
       end
 
       def prepare(handle, key, params)

--- a/test/test_limiter.rb
+++ b/test/test_limiter.rb
@@ -59,6 +59,23 @@ describe Prop::Limiter do
         Prop::Limiter.disabled { Prop.throttle(:something) }.must_equal false
       end
 
+      it "handles concurrency" do
+        disabled_thread = Thread.new do
+          Prop.disabled do
+            Prop.throttle(:something)
+          end
+        end
+
+        enabled_thread = Thread.new do
+          Prop.throttle(:something)
+        end
+
+        disabled_thread.join
+        enabled_thread.join
+
+        Prop.count(:something).must_equal 1
+      end
+
       it "supports decrement and can below 0" do
         Prop.throttle(:something)
         Prop.count(:something).must_equal 1


### PR DESCRIPTION
## Description
When using `Prop.disabled`, `@disabled` can be shared across threads making it unpredictable for paths that do need throttling.

## Changes
Using the thread local to ensure that the variable (`disabled`) is not shared across multiple threads.

## Questions?
Does anyone have a better (or robust) solution for thread-safety for `Prop.disabled?`.