### PR TITLE
[CCORE-331] Use the interval as the ttl when writing a new record to the cache

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+**						@zendesk/bolt

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To store values, prop needs a cache:
 Prop.cache = Rails.cache # needs read/write/increment methods
 ```
 
-Prop does not expire its used keys, so use memcached or similar, not redis.
+When using the interval strategy, prop sets a key expiry to its interval.  Because the leaky bucket strategy does not set a ttl, it is best to use memcached or similar for all prop caching, not redis.
 
 ## Setting a Callback
 

--- a/lib/prop/interval_strategy.rb
+++ b/lib/prop/interval_strategy.rb
@@ -16,16 +16,16 @@ module Prop
       # options argument is kept for api consistency for all strategies
       def increment(cache_key, amount, options = {})
         raise ArgumentError, "Change amount must be a Integer, was #{amount.class}" unless amount.is_a?(Integer)
-        cache.increment(cache_key, amount) || (cache.write(cache_key, amount, raw: true) && amount) # WARNING: potential race condition
+        cache.increment(cache_key, amount) || (cache.write(cache_key, amount, raw: true, expires_in: options.fetch(:interval, nil)) && amount) # WARNING: potential race condition
       end
 
       def decrement(cache_key, amount, options = {})
         raise ArgumentError, "Change amount must be a Integer, was #{amount.class}" unless amount.is_a?(Integer)
-        cache.decrement(cache_key, amount) || (cache.write(cache_key, 0, raw: true) && 0) # WARNING: potential race condition
+        cache.decrement(cache_key, amount) || (cache.write(cache_key, 0, raw: true, expires_in: options.fetch(:interval, nil)) && 0) # WARNING: potential race condition
       end
 
-      def reset(cache_key)
-        cache.write(cache_key, zero_counter, raw: true)
+      def reset(cache_key, options = {})
+        cache.write(cache_key, zero_counter, raw: true, expires_in: options.fetch(:interval, nil))
       end
 
       def compare_threshold?(counter, operator, options)

--- a/lib/prop/leaky_bucket_strategy.rb
+++ b/lib/prop/leaky_bucket_strategy.rb
@@ -62,7 +62,7 @@ module Prop
         [false, bucket]
       end
 
-      def reset(cache_key)
+      def reset(cache_key, options = {})
         cache.write(cache_key, zero_counter, raw: true)
       end
 

--- a/lib/prop/limiter.rb
+++ b/lib/prop/limiter.rb
@@ -120,7 +120,7 @@ module Prop
       # Returns nothing
       def reset(handle, key = nil, options = {})
         _options, cache_key, strategy = prepare(handle, key, options)
-        strategy.reset(cache_key)
+        strategy.reset(cache_key, options)
       end
 
       # Public: Counts the number of times the given handle/key combination has been hit in the current window


### PR DESCRIPTION
Description: Previous versions of prop persist all keys indefinitely.  A key for a previous interval should no longer be considered valid, so having keys never expire only serves to increase the fill % of a memcached cluster and eventually force it in to LRU evictions which is suboptimal for a memcached node's performance.  This change will set a ttl for all records that are written using the interval strategy, with the interval itself as the expires_in value.

JIRA Reference: https://zendesk.atlassian.net/browse/CCORE-331

Risk: High since this is middleware.  In reality, setting the expires_in value whenever interval exists in the options and using nil otherwise should not have any impact on the application because Rails.cache already supports expires_in on write and fetch.