### PR TITLE
[CCORE-331] Set expires_in on increment and decrement

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,13 @@
 # Changes
 
+## 2.6.1
+
+* Bugfix: [CCORE-331] Set expires_in on increment and decrement
+
+## 2.6.0
+
+* [CCORE-331] Use interval value as the ttl when writing to cache
+
 ## 2.5.0
 
 * Bugfix: [USERV-347] Fix leaky bucket implementation

--- a/lib/prop/interval_strategy.rb
+++ b/lib/prop/interval_strategy.rb
@@ -16,12 +16,12 @@ module Prop
       # options argument is kept for api consistency for all strategies
       def increment(cache_key, amount, options = {})
         raise ArgumentError, "Change amount must be a Integer, was #{amount.class}" unless amount.is_a?(Integer)
-        cache.increment(cache_key, amount) || (cache.write(cache_key, amount, raw: true, expires_in: options.fetch(:interval, nil)) && amount) # WARNING: potential race condition
+        cache.increment(cache_key, amount, expires_in: options.fetch(:interval, nil)) || (cache.write(cache_key, amount, raw: true, expires_in: options.fetch(:interval, nil)) && amount) # WARNING: potential race condition
       end
 
       def decrement(cache_key, amount, options = {})
         raise ArgumentError, "Change amount must be a Integer, was #{amount.class}" unless amount.is_a?(Integer)
-        cache.decrement(cache_key, amount) || (cache.write(cache_key, 0, raw: true, expires_in: options.fetch(:interval, nil)) && 0) # WARNING: potential race condition
+        cache.decrement(cache_key, amount, expires_in: options.fetch(:interval, nil)) || (cache.write(cache_key, 0, raw: true, expires_in: options.fetch(:interval, nil)) && 0) # WARNING: potential race condition
       end
 
       def reset(cache_key, options = {})

--- a/test/test_limiter.rb
+++ b/test/test_limiter.rb
@@ -5,7 +5,7 @@ describe Prop::Limiter do
   context "both strategies are being used simultaneously" do
     before do
       cache = setup_fake_store
-      def cache.increment(_, _)
+      def cache.increment(_, _, _)
         sleep 0.0001
       end
 


### PR DESCRIPTION
Description: Items that arrive in the cache by way of an initial increment or decrement operation, rather than a write, should use the interval value as the cache TTL.

JIRA Reference: https://zendesk.atlassian.net/browse/CCORE-331

Risk: High since this is middleware. In reality, setting the expires_in value whenever interval exists in the options and using nil otherwise should not have any impact on the application because Rails.cache already supports expires_in on increment and decrement when using ActiveSupport::Cache::DalliStore.  See: https://www.rubydoc.info/gems/dalli/2.7.7/ActiveSupport%2FCache%2FDalliStore:increment