### PR TITLE
Specify raw when reading raw cache entries

### DIFF
--- a/lib/prop/interval_strategy.rb
+++ b/lib/prop/interval_strategy.rb
@@ -10,7 +10,7 @@ module Prop
       end
 
       def counter(cache_key, options)
-        cache.read(cache_key).to_i
+        cache.read(cache_key, raw: true).to_i
       end
 
       # options argument is kept for api consistency for all strategies


### PR DESCRIPTION
The counters are created with raw, they need to be read the same way.
This primarily affects `.throttled?` and `.count`.

In older rails versions raw entries would often be upgraded to cache
entries but in Rails 7 this no longer happens.