### PR TITLE
IMAX-19: Make error object returns limit threshold

### DIFF
--- a/lib/prop/rate_limited.rb
+++ b/lib/prop/rate_limited.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module Prop
   class RateLimited < StandardError
-    attr_accessor :handle, :cache_key, :retry_after, :description, :first_throttled
+    attr_accessor :handle, :cache_key, :retry_after, :description, :first_throttled, :threshold
 
     def initialize(options)
       self.handle    = options.fetch(:handle)
@@ -11,6 +11,8 @@ module Prop
 
       interval  = options.fetch(:interval).to_i
       self.retry_after = interval - Time.now.to_i % interval
+
+      self.threshold = options.fetch(:threshold)
 
       super(options.fetch(:strategy).threshold_reached(options))
     end

--- a/test/test_rate_limited.rb
+++ b/test/test_rate_limited.rb
@@ -5,7 +5,7 @@ describe Prop::RateLimited do
   before do
     freeze_time 1333685680
 
-    Prop.configure :foo, threshold: 10, interval: 60, category: :api
+    Prop.configure :foo, threshold: 100, interval: 60, category: :api
 
     @error = Prop::RateLimited.new(
       handle: :foo,
@@ -28,12 +28,13 @@ describe Prop::RateLimited do
       @error.description.must_equal "Boom!"
       @error.message.must_equal "foo threshold of 10 tries per 60s exceeded for key nil, hash wibble"
       @error.retry_after.must_equal 20
+      @error.threshold.must_equal 10
     end
   end
 
   describe "#config" do
     it "returns the original configuration" do
-      @error.config[:threshold].must_equal 10
+      @error.config[:threshold].must_equal 100
       @error.config[:interval].must_equal 60
       @error.config[:category].must_equal :api
     end


### PR DESCRIPTION
**Description**

The PR adds the rate limit threshold in-used to the error object. Currently the rate limit threshold in-used is not returned in the error object. This information is required to build rate limit headers.
