### PR TITLE
Fix IntervalStrategy#decrement in ActiveSupport 7.1

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -11,6 +11,14 @@ require 'active_support/cache'
 require 'active_support/cache/memory_store'
 require 'active_support/notifications'
 
+begin
+  require 'active_support/deprecation'
+  require 'active_support/deprecator'
+rescue LoadError
+end
+
+require 'active_support/core_ext/numeric/time'
+
 Minitest::Test.class_eval do
   def setup_fake_store
     Prop.cache = ActiveSupport::Cache::MemoryStore.new


### PR DESCRIPTION
### Context

ActiveSupport 7.1 introduced a breaking change in `ActiveRecord::Cache#decrement`'s behavior:
* prior to 7.1, `decrement` on a new key does nothing and returns nil
* since 7.1, `decrement` on a new key sets its value to 0 first and then decrements, returning a negative value

The new behavior is at odds with `Prop::IntervalStrategy#decrement`'s intended behavior, which sets new keys to 0 when they are decremented.

### Changes

This PR fixes `IntervalStrategy#decrement` by detecting if the return value of `ActiveRecord::Cache#decrement` is nil (< 7.1) or `-amount` (>= 7.1) before clamping the value to 0. This is as vulnerable to a race condition as the existing code, so it's not worse in that regard.

`Prop::IntervalStrategy#increment` does not need a similar change because incrementing a new key is the same as incrementing an existing key set to 0 in ActiveSupport 7.1, just like we intended, and thus the fallback to `write` isn't used in that case.

It also adds some missing `require` statements to the test helper: the time-related ActiveSupport extensions (e.g. `.minutes`) are no longer automatically loaded since Rails 7.1. In turn, `active_support/core_ext/numeric/time` relies on new deprecation-related functionality that isn't automatically loaded either, so we try to load that as well.