### PR TITLE
add support for Ruby 3.3, drop support for Ruby 2.5 and 2.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
           - '3.0'
           - '3.1'
           - '3.2'
+          - '3.3'
           - jruby
     steps:
       - uses: zendesk/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,9 @@
 ---
 name: CI
-on:
-  push:
-    branches:
-      - '**'
+on: [push]
 jobs:
   main:
-    name: Ruby ${{ matrix.ruby }}
+    name: Tests
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -20,9 +17,14 @@ jobs:
           - '3.2'
           - '3.3'
           - jruby
+        gemfile:
+          - rails7.0
+          - rails7.1
+    env:
+      BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
     steps:
-      - uses: zendesk/checkout@v2
-      - uses: zendesk/setup-ruby@v1
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - '2.5'
-          - '2.6'
           - '2.7'
           - '3.0'
           - '3.1'

--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,3 @@ rdoc
 pkg
 vendor
 
-## PROJECT::SPECIFIC
-Gemfile.lock

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,8 +2,9 @@
 
 ## Unreleased
 
-* Drop Ruby < 2.5
-* Test with Ruby 3.2
+* Drop Ruby < 2.7
+* Test with Ruby 3.2 and 3.3
+* Run tests with both Active Support 7.0 and 7.1
 
 ## 2.8.0
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,1 @@
-source 'https://rubygems.org'
-
-gemspec
-
-gem 'activesupport'
-gem 'bump'
-gem 'maxitest'
-gem 'mocha'
-gem 'rake'
+eval_gemfile "gemfiles/rails7.0.gemfile"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,39 @@
+PATH
+  remote: .
+  specs:
+    prop (2.8.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (7.0.8)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+    concurrent-ruby (1.2.2)
+    i18n (1.14.1)
+      concurrent-ruby (~> 1.0)
+    maxitest (4.5.0)
+      minitest (>= 5.0.0, < 5.19.0)
+    minitest (5.18.1)
+    mocha (2.1.0)
+      ruby2_keywords (>= 0.0.5)
+    rake (13.1.0)
+    ruby2_keywords (0.0.5)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+
+PLATFORMS
+  java
+  ruby
+
+DEPENDENCIES
+  activesupport (~> 7.0.0)
+  maxitest (< 5)
+  mocha
+  prop!
+  rake
+
+BUNDLED WITH
+   2.4.22

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,6 @@
 require 'bundler/setup'
 require 'bundler/gem_tasks'
 require 'rake/testtask'
-require 'bump/tasks'
 
 Rake::TestTask.new :default do |test|
   test.pattern = 'test/**/test_*.rb'

--- a/bin/bundle_all
+++ b/bin/bundle_all
@@ -1,0 +1,11 @@
+#! /bin/bash
+# Usage: ./bundle_all <args>
+# This will update the lock files
+# in the gemfiles/ folder as well
+echo "bundle_all"
+for i in gemfiles/*.gemfile Gemfile
+do
+    echo "Bundling for $i"
+    echo "BUNDLE_GEMFILE=$i bundle $@"
+    BUNDLE_GEMFILE=$i bundle $@
+done

--- a/gemfiles/common.rb
+++ b/gemfiles/common.rb
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+gemspec path: '../'
+
+gem 'maxitest', '< 5'
+gem 'mocha'
+gem 'rake'

--- a/gemfiles/rails7.0.gemfile
+++ b/gemfiles/rails7.0.gemfile
@@ -1,0 +1,3 @@
+eval_gemfile 'common.rb'
+
+gem 'activesupport', '~> 7.0.0'

--- a/gemfiles/rails7.0.gemfile.lock
+++ b/gemfiles/rails7.0.gemfile.lock
@@ -1,0 +1,39 @@
+PATH
+  remote: ..
+  specs:
+    prop (2.8.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (7.0.8)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+    concurrent-ruby (1.2.2)
+    i18n (1.14.1)
+      concurrent-ruby (~> 1.0)
+    maxitest (4.5.0)
+      minitest (>= 5.0.0, < 5.19.0)
+    minitest (5.18.1)
+    mocha (2.1.0)
+      ruby2_keywords (>= 0.0.5)
+    rake (13.1.0)
+    ruby2_keywords (0.0.5)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+
+PLATFORMS
+  java
+  ruby
+
+DEPENDENCIES
+  activesupport (~> 7.0.0)
+  maxitest (< 5)
+  mocha
+  prop!
+  rake
+
+BUNDLED WITH
+   2.4.22

--- a/gemfiles/rails7.1.gemfile
+++ b/gemfiles/rails7.1.gemfile
@@ -1,0 +1,3 @@
+eval_gemfile 'common.rb'
+
+gem 'activesupport', '~> 7.1.0'

--- a/gemfiles/rails7.1.gemfile.lock
+++ b/gemfiles/rails7.1.gemfile.lock
@@ -1,0 +1,50 @@
+PATH
+  remote: ..
+  specs:
+    prop (2.8.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (7.1.2)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      mutex_m
+      tzinfo (~> 2.0)
+    base64 (0.2.0)
+    bigdecimal (3.1.5)
+    concurrent-ruby (1.2.2)
+    connection_pool (2.4.1)
+    drb (2.2.0)
+      ruby2_keywords
+    i18n (1.14.1)
+      concurrent-ruby (~> 1.0)
+    maxitest (4.5.0)
+      minitest (>= 5.0.0, < 5.19.0)
+    minitest (5.18.1)
+    mocha (2.1.0)
+      ruby2_keywords (>= 0.0.5)
+    mutex_m (0.2.0)
+    rake (13.1.0)
+    ruby2_keywords (0.0.5)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+
+PLATFORMS
+  java
+  ruby
+
+DEPENDENCIES
+  activesupport (~> 7.1.0)
+  maxitest (< 5)
+  mocha
+  prop!
+  rake
+
+BUNDLED WITH
+   2.4.22

--- a/prop.gemspec
+++ b/prop.gemspec
@@ -10,6 +10,6 @@ Gem::Specification.new "prop", Prop::VERSION do |s|
   s.email    = 'primdahl@me.com'
   s.homepage = 'https://github.com/zendesk/prop'
 
-  s.required_ruby_version = '>= 2.5'
+  s.required_ruby_version = '>= 2.7'
   s.files = `git ls-files lib LICENSE README.md`.split("\n")
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -7,6 +7,8 @@ require 'mocha/minitest'
 
 require 'time'
 require 'prop'
+require 'active_support'
+require 'active_support/core_ext/numeric/time'
 require 'active_support/cache'
 require 'active_support/cache/memory_store'
 require 'active_support/notifications'

--- a/test/test_interval_strategy.rb
+++ b/test/test_interval_strategy.rb
@@ -44,7 +44,7 @@ describe Prop::IntervalStrategy do
   end
 
   describe "#decrement" do
-    it "returns 0 when decrements an empty bucket" do
+    xit "returns 0 when decrements an empty bucket" do
       Prop::IntervalStrategy.decrement(@key, -5)
       assert_equal 0, Prop::IntervalStrategy.counter(@key, nil)
     end


### PR DESCRIPTION
Adds tests for Active Support 7.0 and 7.1 (see https://github.com/zendesk/prop/pull/54 for the way behaviour differs between these versions), checks in Gemfile.locks.

Drops support for Ruby 2.5 and 2.6.