### PR TITLE
[RED-2096] Add after_evaluated callback option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,17 @@ Prop.before_throttle do |handle, key, threshold, interval|
 end
 ```
 
+## Setting an After Evaluated Callback
+
+You can define an optional callback that is invoked when a rate limit is checked. The callback will be invoked regardless
+of the result of the evaluation.
+
+```ruby
+Prop.after_evaluated do |handle, counter, options|
+  Rails.logger.info "Prop #{handle} has just been check. current value: #{counter}"
+end
+````
+
 ## Defining thresholds
 
 Example: Limit on accepted emails per hour from a given user, by defining a threshold and interval (in seconds):

--- a/lib/prop.rb
+++ b/lib/prop.rb
@@ -9,6 +9,6 @@ module Prop
   class << self
     extend Forwardable
     def_delegators :"Prop::Limiter", :read, :write, :cache, :cache=, :configure, :configurations, :disabled, :before_throttle
-    def_delegators :"Prop::Limiter", :throttle, :throttle!, :throttled?, :count, :query, :reset
+    def_delegators :"Prop::Limiter", :throttle, :throttle!, :throttled?, :count, :query, :reset, :after_evaluated
   end
 end

--- a/test/test_limiter.rb
+++ b/test/test_limiter.rb
@@ -67,6 +67,22 @@ describe Prop::Limiter do
         Prop.count(:something).must_equal -4
       end
 
+      describe "when there is a after_evaluated callback" do
+        it "invokes the callback" do
+          Prop.after_evaluated do |handle, counter, options|
+            @handle   = handle
+            @counter  = counter
+            @options  = options
+          end
+
+          Prop.throttle(:something)
+
+          @handle.must_equal :something
+          @counter.must_equal 1
+          @options.must_equal({ threshold: 10, interval: 10, key: "", strategy: Prop::IntervalStrategy })
+        end
+      end
+
       describe "and the threshold has been reached" do
         before { Prop::IntervalStrategy.stubs(:compare_threshold?).returns(true) }
 
@@ -188,6 +204,22 @@ describe Prop::Limiter do
           Prop::Limiter.count(:something).must_equal(
             bucket: 1, last_leak_time: @time.to_i, over_limit: false
           )
+        end
+      end
+
+      describe "when there is a after_evaluated callback" do
+        it "invokes the callback" do
+          Prop.after_evaluated do |handle, counter, options|
+            @handle   = handle
+            @counter  = counter
+            @options  = options
+          end
+
+          Prop.throttle(:something)
+
+          @handle.must_equal :something
+          @counter.must_equal 1
+          @options.keys.sort.must_equal [:bucket, :burst_rate, :interval, :key, :last_leak_time, :over_limit, :strategy, :threshold]
         end
       end
     end


### PR DESCRIPTION
### Description

This PR adds a `after_evaluated` callback option. 

Starting with classic, we want to return a complete list of limit checks in our response headers
example taken from the POC:

```
Zendesk-RateLimit-AccountWideApiRequests: total=100000, remaining=99999, resets=12
Zendesk-RateLimit-ApiTime: total=600, remaining=600, resets=12
Zendesk-RateLimit-ApiRequests: total=700, remaining=699, resets=12
Zendesk-RateLimit-V2TicketsIndex: total=3, remaining=2, resets=11
```
We will be using `ActiveSupport::CurrentAttributes` 

in `.../initializers/prop.rb`

```ruby
 Prop.after_evaluated do |handle, counter, options|
  CurrentPropTrace.log.push({
    handle: handle,
    total: options[:threshold],
    remaining: options[:threshold] - counter,
    resets: options[:interval].to_i - Time.now.to_i % options[:interval],
    options: options
  })
end
```

which will allow us to add headers in our middleware by accessing `CurrentPropTrace.log` 




