### PR TITLE
add tests with Rails main and 7.2, drop support for Ruby below 3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,10 @@ jobs:
         gemfile:
           - rails7.0
           - rails7.1
+          - rails7.2
+        exclude:
+          - { ruby: 'jruby-9.4', gemfile: 'rails_main' }
+          - { ruby: '3.1', gemfile: 'rails_main' }
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,12 +9,10 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - '2.7'
-          - '3.0'
           - '3.1'
           - '3.2'
           - '3.3'
-          - jruby
+          - 'jruby-9.4'
         gemfile:
           - rails7.0
           - rails7.1

--- a/.github/workflows/rails_main_testing.yml
+++ b/.github/workflows/rails_main_testing.yml
@@ -1,0 +1,25 @@
+name: Test against Rails main
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # Run every day at 00:00 UTC
+  workflow_dispatch:
+
+jobs:
+  main:
+    name: Tests
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - '3.3'
+    env:
+      BUNDLE_GEMFILE: gemfiles/rails_main_native.gemfile
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - run: bundle exec rake

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ rdoc
 pkg
 vendor
 
+gemfiles/rails_main.gemfile.lock

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Drop support for Ruby below 3.1
+* Add tests with Active Support 7.2 and Rails main
 
 ## 2.9.0
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Drop support for Ruby below 3.1
+
 ## 2.9.0
 
 * Drop Ruby < 2.7

--- a/gemfiles/rails7.2.gemfile
+++ b/gemfiles/rails7.2.gemfile
@@ -1,0 +1,3 @@
+eval_gemfile 'common.rb'
+
+gem 'activesupport', '~> 7.2.0'

--- a/gemfiles/rails7.2.gemfile.lock
+++ b/gemfiles/rails7.2.gemfile.lock
@@ -1,0 +1,52 @@
+PATH
+  remote: ..
+  specs:
+    prop (2.9.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (7.2.1)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+    base64 (0.2.0)
+    bigdecimal (3.1.8)
+    bigdecimal (3.1.8-java)
+    concurrent-ruby (1.3.4)
+    connection_pool (2.4.1)
+    drb (2.2.1)
+    i18n (1.14.6)
+      concurrent-ruby (~> 1.0)
+    logger (1.6.1)
+    maxitest (4.5.0)
+      minitest (>= 5.0.0, < 5.19.0)
+    minitest (5.18.1)
+    mocha (2.4.5)
+      ruby2_keywords (>= 0.0.5)
+    rake (13.2.1)
+    ruby2_keywords (0.0.5)
+    securerandom (0.3.1)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+
+PLATFORMS
+  java
+  ruby
+
+DEPENDENCIES
+  activesupport (~> 7.2.0)
+  maxitest (< 5)
+  mocha
+  prop!
+  rake
+
+BUNDLED WITH
+   2.5.9

--- a/gemfiles/rails_main.gemfile
+++ b/gemfiles/rails_main.gemfile
@@ -1,0 +1,4 @@
+eval_gemfile 'common.rb'
+
+gem "activesupport", github: "rails/rails"
+

--- a/prop.gemspec
+++ b/prop.gemspec
@@ -10,6 +10,6 @@ Gem::Specification.new "prop", Prop::VERSION do |s|
   s.email    = 'primdahl@me.com'
   s.homepage = 'https://github.com/zendesk/prop'
 
-  s.required_ruby_version = '>= 2.7'
+  s.required_ruby_version = '>= 3.1'
   s.files = `git ls-files lib LICENSE README.md`.split("\n")
 end


### PR DESCRIPTION
Ruby 2.7 and 3.0 are EOL, so we can drop them.
I’ve also switched to listing a specific JRuby version (which is in fact the same 9.4 as before, as Active Support 7.x does not support Ruby 2.6 / JRuby 9.3).