### PR TITLE
Add tests with Ruby 3.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,14 @@ jobs:
           - '3.1'
           - '3.2'
           - '3.3'
+          - '3.4'
           - 'jruby-9.4'
         gemfile:
           - rails7.0
           - rails7.1
           - rails7.2
         include:
-          - { ruby: '3.3', gemfile: 'rails_main' }
+          - { ruby: '3.4', gemfile: 'rails_main' }
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
     steps:

--- a/.github/workflows/rails_main_testing.yml
+++ b/.github/workflows/rails_main_testing.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - '3.3'
+          - '3.4'
     env:
       BUNDLE_GEMFILE: gemfiles/rails_main.gemfile
     steps:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,14 +11,18 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
+    base64 (0.2.0)
+    bigdecimal (3.1.9)
+    bigdecimal (3.1.9-java)
     concurrent-ruby (1.2.3)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    maxitest (4.5.0)
-      minitest (>= 5.0.0, < 5.19.0)
-    minitest (5.18.1)
+    maxitest (5.8.0)
+      minitest (>= 5.14.0, < 5.26.0)
+    minitest (5.25.4)
     mocha (2.1.0)
       ruby2_keywords (>= 0.0.5)
+    mutex_m (0.3.0)
     rake (13.1.0)
     ruby2_keywords (0.0.5)
     tzinfo (2.0.6)
@@ -30,10 +34,13 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport (~> 7.0.0)
-  maxitest (< 5)
+  base64
+  bigdecimal
+  maxitest
   mocha
+  mutex_m
   prop!
   rake
 
 BUNDLED WITH
-   2.5.6
+   2.6.2

--- a/gemfiles/common.rb
+++ b/gemfiles/common.rb
@@ -2,6 +2,6 @@ source 'https://rubygems.org'
 
 gemspec path: '../'
 
-gem 'maxitest', '< 5'
+gem 'maxitest'
 gem 'mocha'
 gem 'rake'

--- a/gemfiles/rails7.0.gemfile
+++ b/gemfiles/rails7.0.gemfile
@@ -1,3 +1,6 @@
 eval_gemfile 'common.rb'
 
 gem 'activesupport', '~> 7.0.0'
+gem 'base64'
+gem 'bigdecimal'
+gem 'mutex_m'

--- a/gemfiles/rails7.0.gemfile.lock
+++ b/gemfiles/rails7.0.gemfile.lock
@@ -11,14 +11,18 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
+    base64 (0.2.0)
+    bigdecimal (3.1.9)
+    bigdecimal (3.1.9-java)
     concurrent-ruby (1.2.2)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    maxitest (4.5.0)
-      minitest (>= 5.0.0, < 5.19.0)
-    minitest (5.18.1)
+    maxitest (5.8.0)
+      minitest (>= 5.14.0, < 5.26.0)
+    minitest (5.25.4)
     mocha (2.1.0)
       ruby2_keywords (>= 0.0.5)
+    mutex_m (0.3.0)
     rake (13.1.0)
     ruby2_keywords (0.0.5)
     tzinfo (2.0.6)
@@ -30,10 +34,13 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport (~> 7.0.0)
-  maxitest (< 5)
+  base64
+  bigdecimal
+  maxitest
   mocha
+  mutex_m
   prop!
   rake
 
 BUNDLED WITH
-   2.4.22
+   2.6.2

--- a/gemfiles/rails7.1.gemfile.lock
+++ b/gemfiles/rails7.1.gemfile.lock
@@ -25,9 +25,9 @@ GEM
       ruby2_keywords
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    maxitest (4.5.0)
-      minitest (>= 5.0.0, < 5.19.0)
-    minitest (5.18.1)
+    maxitest (5.8.0)
+      minitest (>= 5.14.0, < 5.26.0)
+    minitest (5.25.4)
     mocha (2.1.0)
       ruby2_keywords (>= 0.0.5)
     mutex_m (0.2.0)
@@ -42,10 +42,10 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport (~> 7.1.0)
-  maxitest (< 5)
+  maxitest
   mocha
   prop!
   rake
 
 BUNDLED WITH
-   2.4.22
+   2.6.2

--- a/gemfiles/rails7.2.gemfile.lock
+++ b/gemfiles/rails7.2.gemfile.lock
@@ -26,9 +26,9 @@ GEM
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
     logger (1.6.1)
-    maxitest (4.5.0)
-      minitest (>= 5.0.0, < 5.19.0)
-    minitest (5.18.1)
+    maxitest (5.8.0)
+      minitest (>= 5.14.0, < 5.26.0)
+    minitest (5.25.4)
     mocha (2.4.5)
       ruby2_keywords (>= 0.0.5)
     rake (13.2.1)
@@ -43,10 +43,10 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport (~> 7.2.0)
-  maxitest (< 5)
+  maxitest
   mocha
   prop!
   rake
 
 BUNDLED WITH
-   2.5.9
+   2.6.2


### PR DESCRIPTION
Adds tests with Ruby 3.4.

base64, bigdecimal, and mutex_m need to be added to Gemfiles for Rails 6.1 and 7.0 tests (Rails 7.1 and above lists them as dependencies). I’ve also updated maxitest and minitest to versions supporting Ruby 3.4.