### PR TITLE
Switch to trusted publishing workflow and run it on version.rb changes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,12 +1,26 @@
-name: Publish Gem
+name: Publish to RubyGems.org
 
 on:
   push:
-    tags: v*
+    branches: main
+    paths: lib/prop/version.rb
+  workflow_dispatch:
 
 jobs:
-  call-workflow:
-    uses: zendesk/gw/.github/workflows/ruby-gem-publication.yml@main
-    secrets:
-      RUBY_GEMS_API_KEY: ${{ secrets.RUBY_GEMS_API_KEY }}
-      RUBY_GEMS_TOTP_DEVICE: ${{ secrets.RUBY_GEMS_TOTP_DEVICE }}
+  publish:
+    runs-on: ubuntu-latest
+    environment: rubygems-publish
+    if: github.repository_owner == 'zendesk'
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: false
+          ruby-version: "3.4"
+      - name: Install dependencies
+        run: bundle install
+      - uses: rubygems/release-gem@v1

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # Prop ![Build status](https://github.com/zendesk/prop/workflows/ci/badge.svg)
 
 A gem to rate limit requests/actions of any kind.<br/>
@@ -40,7 +39,7 @@ of the result of the evaluation.
 Prop.after_evaluated do |handle, counter, options|
   Rails.logger.info "Prop #{handle} has just been check. current value: #{counter}"
 end
-````
+```
 
 ## Defining thresholds
 
@@ -246,6 +245,20 @@ Prop.configure(:api_request, strategy: :leaky_bucket, burst_rate: 20, threshold:
 
 * `:threshold` value here would be the "leak rate" of leaky bucket algorithm.
 
+### Releasing a new version
+A new version is published to RubyGems.org every time a change to `version.rb` is pushed to the `main` branch.
+In short, follow these steps:
+1. Update `version.rb`,
+2. update version in all `Gemfile.lock` files,
+3. merge this change into `main`, and
+4. look at [the action](https://github.com/zendesk/prop/actions/workflows/publish.yml) for output.
+
+To create a pre-release from a non-main branch:
+1. change the version in `version.rb` to something like `1.2.0.pre.1` or `2.0.0.beta.2`,
+2. push this change to your branch,
+3. go to [Actions → “Publish to RubyGems.org” on GitHub](https://github.com/zendesk/prop/actions/workflows/publish.yml),
+4. click the “Run workflow” button,
+5. pick your branch from a dropdown.
 
 ## License
 

--- a/lib/prop.rb
+++ b/lib/prop.rb
@@ -3,9 +3,7 @@ require "prop/limiter"
 require "forwardable"
 
 module Prop
-  VERSION = "2.9.0"
-
-  # Short hand for accessing Prop::Limiter methods
+  # Shorthand for accessing Prop::Limiter methods
   class << self
     extend Forwardable
     def_delegators :"Prop::Limiter", :read, :write, :cache, :cache=, :configure, :configurations, :disabled, :before_throttle

--- a/lib/prop/version.rb
+++ b/lib/prop/version.rb
@@ -1,0 +1,3 @@
+module Prop
+  VERSION = "2.9.0"
+end

--- a/prop.gemspec
+++ b/prop.gemspec
@@ -1,5 +1,4 @@
-$LOAD_PATH.unshift "lib"
-require "prop"
+require_relative "lib/prop/version"
 
 Gem::Specification.new "prop", Prop::VERSION do |s|
   s.license = "Apache License Version 2.0"


### PR DESCRIPTION
Switches to [a Trusted Publishing workflow](https://guides.rubygems.org/trusted-publishing/).
This workflow will run whenever `version.rb` is changed in the `main` branch.
Setting `ENV["gem_push"]` is also not necessary anymore.

`bundler-cache` for `setup-ruby` is set to false to prevent [cache poisoning attacks](https://adnanthekhan.com/2024/05/06/the-monsters-in-your-build-cache-github-actions-cache-poisoning/).
Finally, we add a description of the new release process. Our README and CONTRIBUTING files don’t have a standard structure, so please check that we have updated a correct file and that the new section makes sense for this gem.
- [x] Release description has been updated correctly.