### PR TITLE
Update list of tested Rails versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
           - rails7.0
           - rails7.1
           - rails7.2
+          - rails8.0
+          - rails8.1
         include:
           - { ruby: '3.4', gemfile: 'rails_main' }
     env:

--- a/gemfiles/rails8.0.gemfile
+++ b/gemfiles/rails8.0.gemfile
@@ -1,0 +1,3 @@
+eval_gemfile 'common.rb'
+
+gem 'activesupport', '~> 8.0.0'

--- a/gemfiles/rails8.0.gemfile.lock
+++ b/gemfiles/rails8.0.gemfile.lock
@@ -1,0 +1,55 @@
+PATH
+  remote: ..
+  specs:
+    prop (2.9.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (8.0.3)
+      base64
+      benchmark (>= 0.3)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
+    base64 (0.3.0)
+    benchmark (0.5.0)
+    bigdecimal (3.3.1)
+    concurrent-ruby (1.3.5)
+    connection_pool (2.5.4)
+    drb (2.2.3)
+    i18n (1.14.7)
+      concurrent-ruby (~> 1.0)
+    logger (1.7.0)
+    maxitest (6.0.1)
+      minitest (>= 5.20.0, < 5.26.0)
+    minitest (5.25.5)
+    mocha (2.7.1)
+      ruby2_keywords (>= 0.0.5)
+    rake (13.3.0)
+    ruby2_keywords (0.0.5)
+    securerandom (0.4.1)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    uri (1.0.4)
+
+PLATFORMS
+  aarch64-linux
+  ruby
+
+DEPENDENCIES
+  activesupport (~> 8.0.0)
+  maxitest
+  mocha
+  prop!
+  rake
+
+BUNDLED WITH
+   2.6.9

--- a/gemfiles/rails8.1.gemfile
+++ b/gemfiles/rails8.1.gemfile
@@ -1,0 +1,3 @@
+eval_gemfile 'common.rb'
+
+gem 'activesupport', '~> 8.1.0'

--- a/gemfiles/rails8.1.gemfile.lock
+++ b/gemfiles/rails8.1.gemfile.lock
@@ -1,0 +1,55 @@
+PATH
+  remote: ..
+  specs:
+    prop (2.9.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (8.1.0)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      json
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
+    base64 (0.3.0)
+    bigdecimal (3.3.1)
+    concurrent-ruby (1.3.5)
+    connection_pool (2.5.4)
+    drb (2.2.3)
+    i18n (1.14.7)
+      concurrent-ruby (~> 1.0)
+    json (2.15.1)
+    logger (1.7.0)
+    maxitest (6.0.1)
+      minitest (>= 5.20.0, < 5.26.0)
+    minitest (5.25.5)
+    mocha (2.7.1)
+      ruby2_keywords (>= 0.0.5)
+    rake (13.3.0)
+    ruby2_keywords (0.0.5)
+    securerandom (0.4.1)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    uri (1.0.4)
+
+PLATFORMS
+  aarch64-linux
+  ruby
+
+DEPENDENCIES
+  activesupport (~> 8.1.0)
+  maxitest
+  mocha
+  prop!
+  rake
+
+BUNDLED WITH
+   2.6.9


### PR DESCRIPTION
Adds Rails 8.1 to the testing matrix, checks that the list of Rails versions still matches what is used by services where this gem is installed.